### PR TITLE
Make MixinRemapper not final

### DIFF
--- a/src/main/java/net/fabricmc/mapping/util/MixinRemapper.java
+++ b/src/main/java/net/fabricmc/mapping/util/MixinRemapper.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * A simple implementation of a mixin remapper backed by a tree mapping.
  */
-public final class MixinRemapper implements IRemapper {
+public class MixinRemapper implements IRemapper {
 
 	private final Map<EntryTriple, String> fieldNames = new HashMap<>();
 	private final Map<EntryTriple, String> methodNames = new HashMap<>();


### PR DESCRIPTION
Considering [the only current usage of this class is via inheritance](https://github.com/FabricMC/fabric-loader/blob/master/src/main/java/net/fabricmc/loader/util/mappings/MixinIntermediaryDevRemapper.java), I think it makes sense to make it inheritable. 